### PR TITLE
Add basic theme

### DIFF
--- a/src/components/App/index.js
+++ b/src/components/App/index.js
@@ -1,16 +1,19 @@
 import React from 'react';
-import { GlobalStyle, Wrapper } from './styles';
+import { ThemeProvider } from 'styled-components';
 
+import theme from '../../styles/theme';
 import MainMap from '../MainMap';
 import SignIn from '../SignIn';
+import { GlobalStyle, Wrapper } from './styles';
 
 const App = () => (
-  <Wrapper>
-    <GlobalStyle />
-
-    <MainMap />
-    <SignIn />
-  </Wrapper>
+  <ThemeProvider theme={theme}>
+    <Wrapper>
+      <GlobalStyle />
+      <MainMap />
+      <SignIn />
+    </Wrapper>
+  </ThemeProvider>
 );
 
 export default App;

--- a/src/components/App/styles.js
+++ b/src/components/App/styles.js
@@ -9,8 +9,8 @@ export const GlobalStyle = createGlobalStyle`
     padding: 0;
     margin: 0;
     font-family: 'Open Sans', sans-serif;
-    background-color: #DAE1E7;
-    color: #22292F;
+    background-color: ${props => props.theme.neutralLight};
+    color: ${props => props.theme.neutralDark};
   }
 `;
 

--- a/src/components/SignIn/styles.js
+++ b/src/components/SignIn/styles.js
@@ -6,7 +6,7 @@ export const Container = styled.div`
   background-color: white;
   padding:  0.75rem;
   border-radius: 9999px;
-  box-shadow: 0 2px 4px 0 rgba(0, 0 ,0 , 0.10);
+  box-shadow: ${props => props.theme.shadow};
   position: fixed;
   top: 1rem;
   right: 1rem;

--- a/src/styles/theme.js
+++ b/src/styles/theme.js
@@ -1,0 +1,7 @@
+const theme = {
+  neutralLight: '#dae1e7',
+  neutralDark: '#22292f',
+  shadow: '0 2px 4px 0 rgba(0, 0 ,0 , 0.10)'
+};
+
+export default theme;


### PR DESCRIPTION
Closes #11.

Adds a theme for Styled Components to make common colors, shadows, fonts, etc. available throughout the application. The theme is very simple for now but will grow as we build out more components and identify shared styles.